### PR TITLE
use FORCE INDEX to apply index for order by in posts table

### DIFF
--- a/webapp/golang/app.go
+++ b/webapp/golang/app.go
@@ -387,7 +387,7 @@ func getIndex(w http.ResponseWriter, r *http.Request) {
 
 	results := []Post{}
 
-	err := db.Select(&results, "SELECT `id`, `user_id`, `body`, `mime`, `created_at` FROM `posts` ORDER BY `created_at` DESC")
+	err := db.Select(&results, "SELECT `id`, `user_id`, `body`, `mime`, `created_at` FROM `posts` force index (idx_created_at_desc) ORDER BY `created_at` DESC")
 	if err != nil {
 		log.Print(err)
 		return


### PR DESCRIPTION
`Using filesort`じゃなくなったのでいいのでは
```
mysql> explain SELECT `id`, `user_id`, `body`, `mime`, `created_at` FROM `posts` use index (idx_created_at_desc) ORDER BY `created_at` DESC;
+----+-------------+-------+------------+------+---------------+------+---------+------+------+----------+----------------+
| id | select_type | table | partitions | type | possible_keys | key  | key_len | ref  | rows | filtered | Extra          |
+----+-------------+-------+------------+------+---------------+------+---------+------+------+----------+----------------+
|  1 | SIMPLE      | posts | NULL       | ALL  | NULL          | NULL | NULL    | NULL | 9390 |   100.00 | Using filesort |
+----+-------------+-------+------------+------+---------------+------+---------+------+------+----------+----------------+
1 row in set, 1 warning (0.00 sec)

mysql> explain SELECT `id`, `user_id`, `body`, `mime`, `created_at` FROM `posts` force index (idx_created_at_desc) ORDER BY `created_at` DESC;
+----+-------------+-------+------------+-------+---------------+---------------------+---------+------+------+----------+-------+
| id | select_type | table | partitions | type  | possible_keys | key                 | key_len | ref  | rows | filtered | Extra |
+----+-------------+-------+------------+-------+---------------+---------------------+---------+------+------+----------+-------+
|  1 | SIMPLE      | posts | NULL       | index | NULL          | idx_created_at_desc | 4       | NULL | 9390 |   100.00 | NULL  |
+----+-------------+-------+------------+-------+---------------+---------------------+---------+------+------+----------+-------+
1 row in set, 1 warning (0.00 sec)
```